### PR TITLE
Changed to handling passwords in a more 'pure' way.

### DIFF
--- a/ajax/login.php
+++ b/ajax/login.php
@@ -1,26 +1,26 @@
 <?php
    $path = DIRNAME(__FILE__);
    include("$path/../config.php");
-	
+
 	start_session("zmap");
 	begin();
-	
+
 	if (!isset($_POST['user']) || !isset($_POST['password'])) {
 		echo json_encode(array("success"=>false, "msg"=>"Ops, something went wrong..."));
-		return;		
+		return;
 	}
-   
+
    $username = $mysqli->real_escape_string($_POST['user']);
    $password = $mysqli->real_escape_string($_POST['password']);
    $passwordUnescaped = $_POST['password'];
    $ip = preg_replace('#[^0-9.]#', '', getenv('REMOTE_ADDR'));
-   
-   
+
+
    $query = "select id, username, password, level from " . $map_prefix . "user " .
             " where username = '" . $username . "'"
             ;
 	$result = $mysqli->query($query);
-   
+
    if ($result) {
       $row = $result->fetch_assoc();
       if (isset($row['password'])
@@ -34,7 +34,7 @@
          $user['level'] = $row['level'];
 
          $hash = password_hash($username . $row['password'], PASSWORD_DEFAULT, ['cost' => 13]);
-         
+
          if (isset($_POST['remember'])) {
             setcookie('user_id', $user['id'], strtotime( '+30 days' ), "/", "", "", TRUE);
             setcookie('username', $user['username'], strtotime( '+30 days' ), "/", "", "", TRUE);
@@ -45,12 +45,12 @@
          $_SESSION['user_id'] = $user['id'];
          $_SESSION['r'] = $hash;
          $_SESSION['level'] = $user['level'];
-         
+
          $uquery = "update " . $map_prefix . "user set ip = '" . $ip . "', last_login=now() where id = " . $row['id'];
          //echo $uquery;
          $mysqli->query($uquery);
          commit();
-         
+
          echo json_encode(array("success"=>true, "msg"=>"Success!", "user"=>$user));
 
       } else {

--- a/ajax/user_add.php
+++ b/ajax/user_add.php
@@ -1,15 +1,15 @@
 <?php
    $path = DIRNAME(__FILE__);
    include("$path/../config.php");
-	
+
 	start_session("zmap");
 	begin();
-	
+
 	if (!isset($_POST['user']) || !isset($_POST['password']) || !isset($_POST['name']) || !isset($_POST['email'])) {
 		echo json_encode(array("success"=>false, "msg"=>"Must fill all the form fields"));
-		return;		
+		return;
 	}
-   
+
    $username = $mysqli->real_escape_string($_POST['user']);
    $passwordUnescaped = $_POST['password'];
    $name = $mysqli->real_escape_string($_POST['name']);
@@ -21,7 +21,7 @@
             ;
    //echo $query;
 	$result = $mysqli->query($query);
-   
+
    if ($result) {
       commit();
       echo json_encode(array("success"=>true, "msg"=>"Success! User created!"));


### PR DESCRIPTION
Became a problem when I was trying to reset passwords, which would need to have a consistent algorithm.

I felt it as simpler using the password as-is, instead of escaping it, since we do and should not present it to the user or anyone else, or otherwise store it in its raw form.

Since we don't want to try to perform a password migration, since this isn't a critical issue, and especially since they are only known 'one-way' (hashed), there is no easy method to do this, so I change the login method to accept both forms for now.

Naïvely speaking, this should not reduce the complexity and safety/security of the passwords much at all, since we should all be using a large amount of characters for, and unique passwords for each account we have.