### PR TITLE
Fix fitBounds from url query string not working

### DIFF
--- a/scripts/zmain.js
+++ b/scripts/zmain.js
@@ -191,6 +191,7 @@ $.getJSON("ajax.php?command=get_container&game=" + gameId, function(vResults){
 
       if (vContainer.fitBounds) {
          var fitBoundsCoordinates = vContainer.fitBounds.split(','); // 0,0,0,0 -> [0,0,0,0]
+         vContainer.fitBounds = [[NaN,NaN],[NaN,NaN]]; //Re-initialise
          for (var i=0; i<4; i++) {
             var ordinate = parseFloat(fitBoundsCoordinates[i]);
             if (ordinate != NaN) {


### PR DESCRIPTION
Added a line to re-initialise vContainer.fitBounds as a 2x2 matrix

Tested with:
```
vContainer = {};      
vContainer.fitBounds                  = "1,2,3,4";

      if (vContainer.fitBounds) {
         var fitBoundsCoordinates = vContainer.fitBounds.split(','); // 0,0,0,0 -> [0,0,0,0]
         vContainer.fitBounds = [[NaN,NaN],[NaN,NaN]]; //Re-initialise
         for (var i=0; i<4; i++) {
            var ordinate = parseFloat(fitBoundsCoordinates[i]);
            if (ordinate != NaN) {
               vContainer.fitBounds[Math.floor(i/2)][i%2] = ordinate;
            } else {
               vContainer.fitBounds = false;
               break;
            }
         }
      }
console.log(vContainer.fitBounds);
```