### PR TITLE
Leaflet update to 1.5.1+build.2e3e0ffb + Bugfixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
       <!-- Third-Party LIBs -->
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.5.1/leaflet-src.js"></script>
       <script defer src="https://use.fontawesome.com/releases/v5.0.13/js/all.js" integrity="sha384-xymdQtn1n3lH2wcu0qhcdaOpQwyoarkgLVxC/wZ5q7h9gHtxICrpcaSUfygqZGOe" crossorigin="anonymous"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.0.4/fuse.min.js"></script>
@@ -35,7 +35,7 @@
       <script>tinymce.init({ selector:'textarea' });</script>
 
       <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous" />
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css" />
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.5.1/leaflet.css" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" />
 
       <!-- LIBs -->

--- a/scripts/controls/ZLayers.js
+++ b/scripts/controls/ZLayers.js
@@ -31,7 +31,8 @@ L.Control.ZLayers = L.Control.Layers.extend({
     this._debugName = this.name;
   },
 
-  initialize: function (baseLayers, categoryTree, options) {
+  initialize: function (baseLayers, overlays, options) {
+    this._layers = [];
     this._setDebugNames();
     this.options = this.options; // Fixes `hasOwnProperty` issue in `setOptions` to be `true` now....
     L.Util.setOptions(this, options); // Same as L.setOptions in the Leaflet doc.  I like using this namespace better.  Shows intent more clearly.
@@ -170,7 +171,7 @@ L.Control.ZLayers = L.Control.Layers.extend({
                _thisLayer._mapsButton.clear();
            }
 
-	      } // Where should the cookie code come from.... some config object with an abstracted persistence layer?,
+	      }.bind(this) // Where should the cookie code come from.... some config object with an abstracted persistence layer?,
       });
       // this.categoryButtonCompleted.domNode.on('toggle', opts.onCompletedToggle.bind(this.categoryButtonCompleted));
       $(headerMenu).append(this._gamesButton.domNode);
@@ -194,7 +195,7 @@ L.Control.ZLayers = L.Control.Layers.extend({
       this._contents.style.width = '360px';
 
 		container.appendChild(form1);
-    container.appendChild(this._contents);
+		container.appendChild(this._contents);
    },
    
    rebuildMapsMenu: function () {
@@ -222,7 +223,7 @@ L.Control.ZLayers = L.Control.Layers.extend({
      onCategoryToggle: function(toggledOn, category) {
        (
          window.location.replace(location.protocol + '//' + location.host + location.pathname + "?game=" + category.shortName)
-       ).call(zMap, category, toggledOn)
+       )
      }.bind(this), // TODO: Have a handler pass in the zMap's method from even higher above, for this function and others?!
      categorySelectionMethod: this.options.categorySelectionMethod,
      defaultToggledState: (this.options.categorySelectionMethod == "focus")
@@ -445,7 +446,25 @@ L.Control.ZLayers = L.Control.Layers.extend({
     } else {
       setContentFunction();
     }
-  }
+  },
+  
+	// @method expand(): this
+	// Expand the control container if collapsed.
+	expand: function () {
+		L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
+      if (this._section) {
+         this._section.style.height = null;
+         var acceptableHeight = this._map.getSize().y - (this._container.offsetTop + 50);
+         if (acceptableHeight < this._section.clientHeight) {
+            DomUtil.addClass(this._section, 'leaflet-control-layers-scrollbar');
+            this._section.style.height = acceptableHeight + 'px';
+         } else {
+            DomUtil.removeClass(this._section, 'leaflet-control-layers-scrollbar');
+         }
+      }
+		this._checkDisabledLayers();
+		return this;
+	},
 });
 
 L.Control.ZLayers.prototype._className = "L.Control.ZLayers";

--- a/scripts/widgets/CategoryMenu.js
+++ b/scripts/widgets/CategoryMenu.js
@@ -69,8 +69,10 @@ CategoryMenu.prototype._addCategoryMenuEntry = function(categoryButton) {
 CategoryMenu.prototype.customToggle = function() {
   this.onToggle(this.toggledOn, this.category);
   categories.forEach(function(category) {
-    category._button.toggledOn = ((hasUserCheck) ? category.userChecked : category.checked);
-    category._button._updateState();
+     if (category._button) {
+         category._button.toggledOn = ((hasUserCheck) ? category.userChecked : category.checked);
+         category._button._updateState();
+     }
   });
   zMap.refreshMap(categories);
 };

--- a/scripts/widgets/GameMenu.js
+++ b/scripts/widgets/GameMenu.js
@@ -47,8 +47,10 @@ GameMenu.prototype._addGameMenuEntry = function(categoryButton) {
 GameMenu.prototype.customToggle = function() {
   this.onToggle(this.toggledOn, this.category);
   categories.forEach(function(category) {
-    category._button.toggledOn = ((hasUserCheck) ? category.userChecked : category.checked);
-    category._button._updateState();
+     if (category._button) {
+         category._button.toggledOn = ((hasUserCheck) ? category.userChecked : category.checked);
+         category._button._updateState();
+     }
   });
   zMap.refreshMap(categories);
 };

--- a/scripts/zmap.js
+++ b/scripts/zmap.js
@@ -678,8 +678,8 @@ ZMap.prototype.buildMap = function() {
    } else {
       mapControl = L.control.zlayers(
         baseMaps,
-        categoryTree,
-        mapControlOptions
+        {},
+        mapControlOptions,
       );
       L.control.zoom({ position:'bottomright' }).addTo(map);
       if (mapOptions.showInfoControls) {


### PR DESCRIPTION
- Updated Leaflet to 1.5.1+build.2e3e0ffb
- Changed ZLayers control (old version worked, new didn`t with added function expand)
- Removed categoryTree as a parameter. It was on the position of the overlays. CategoryTree is a global var, we may need to change that in the future to pass as a mapControlOption to encapsulate things
- Added some checks to ensure things don`t break.